### PR TITLE
feat(rfid): add RFID service layer and cabinet verification use case

### DIFF
--- a/apps/pharmed-client/lib/core/hardware/model/rfid_tag.dart
+++ b/apps/pharmed-client/lib/core/hardware/model/rfid_tag.dart
@@ -1,0 +1,16 @@
+class RfidTag {
+  final String epc; // 12 byte hex string, unique identifier
+  final int rssi; // dBm cinsinden sinyal gücü
+  final int antenna; // anten numarası
+
+  const RfidTag({required this.epc, required this.rssi, required this.antenna});
+
+  @override
+  bool operator ==(Object other) => other is RfidTag && other.epc == epc;
+
+  @override
+  int get hashCode => epc.hashCode;
+
+  @override
+  String toString() => 'RfidTag(epc: $epc, rssi: $rssi dBm)';
+}

--- a/apps/pharmed-client/lib/core/hardware/service/rfid/i_rfid_service.dart
+++ b/apps/pharmed-client/lib/core/hardware/service/rfid/i_rfid_service.dart
@@ -1,0 +1,22 @@
+import 'package:pharmed_core/pharmed_core.dart';
+
+import '../../model/rfid_tag.dart';
+
+abstract interface class IRfidService {
+  /// TCP bağlantısı kurar. Uygulama başlangıcında veya
+  /// operasyon öncesinde bir kez çağrılır.
+  Future<Result<void>> connect(String host, int port);
+
+  /// Bağlantıyı kapatır.
+  Future<void> disconnect();
+
+  /// Bağlantı durumu.
+  bool get isConnected;
+
+  /// Antendeki tüm tag'leri okur (2 saniyelik scan).
+  /// Aynı EPC birden fazla gelirse en yüksek RSSI saklanır.
+  Future<Result<List<RfidTag>>> scan();
+
+  /// RF güç seviyesini ayarlar (dBm).
+  Future<Result<void>> setPower(int dbm);
+}

--- a/apps/pharmed-client/lib/core/hardware/service/rfid/mock_rfid_service.dart
+++ b/apps/pharmed-client/lib/core/hardware/service/rfid/mock_rfid_service.dart
@@ -1,0 +1,59 @@
+// pharmed-client/core/hardware/service/rfid/mock_rfid_service.dart
+
+import 'package:pharmed_core/pharmed_core.dart';
+
+import '../../model/rfid_tag.dart';
+import 'i_rfid_service.dart';
+
+/// Dev/test flavor için sabit tag listesi döner.
+/// Gerçek TCP bağlantısı kurmaz.
+class MockRfidService implements IRfidService {
+  static const _mockTags = [
+    RfidTag(epc: '010CE280689400005017CFB6', rssi: -45, antenna: 1),
+    RfidTag(epc: '010CE280689400004017CFB5', rssi: -52, antenna: 1),
+    RfidTag(epc: '010CE280689400003017CFB4', rssi: -48, antenna: 1),
+    RfidTag(epc: '010CE280689400002017CFB3', rssi: -61, antenna: 1),
+    RfidTag(epc: '010CE280689400001017CFB2', rssi: -55, antenna: 1),
+    RfidTag(epc: '010CE280689400000017CFB1', rssi: -43, antenna: 1),
+    RfidTag(epc: '010CE280689400009017CFB0', rssi: -58, antenna: 1),
+    RfidTag(epc: '010CE280689400008017CFAF', rssi: -50, antenna: 1),
+    RfidTag(epc: '010CE280689400007017CFAE', rssi: -47, antenna: 1),
+    RfidTag(epc: '010CE280689400006017CFAD', rssi: -54, antenna: 1),
+  ];
+
+  bool _connected = false;
+
+  /// Mock: scan çağrıldığında bu index'ten sonraki tag'leri döner.
+  /// Test senaryolarında dışarıdan set edilebilir.
+  List<RfidTag> mockTags = List.of(_mockTags);
+
+  @override
+  bool get isConnected => _connected;
+
+  @override
+  Future<Result<void>> connect(String host, int port) async {
+    await Future.delayed(const Duration(milliseconds: 100));
+    _connected = true;
+    return const Result.ok(null);
+  }
+
+  @override
+  Future<void> disconnect() async {
+    _connected = false;
+  }
+
+  @override
+  Future<Result<List<RfidTag>>> scan() async {
+    if (!_connected) {
+      return Result.error(ServiceException(message: 'Mock RFID servisi bağlı değil.', statusCode: 503));
+    }
+    // Gerçek scan süresini simüle et
+    await Future.delayed(const Duration(seconds: 2));
+    return Result.ok(List.of(mockTags));
+  }
+
+  @override
+  Future<Result<void>> setPower(int dbm) async {
+    return const Result.ok(null);
+  }
+}

--- a/apps/pharmed-client/lib/core/hardware/service/rfid/rfid_service.dart
+++ b/apps/pharmed-client/lib/core/hardware/service/rfid/rfid_service.dart
@@ -1,0 +1,216 @@
+// pharmed-client/core/hardware/service/rfid/rfid_service.dart
+
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:pharmed_core/pharmed_core.dart';
+import 'package:pharmed_ui/pharmed_ui.dart';
+
+import '../../model/rfid_tag.dart';
+import 'i_rfid_service.dart';
+
+/// RFID okuyucu ile TCP üzerinden haberleşen gerçek implementasyon.
+///
+/// Protokol: CRC-16/MCRF4XX (poly=0x1021, init=0xFFFF, reflected, LSB-first)
+/// Paket yapısı: [Len][Addr=0x00][CMD][Data...][CRC_LSB][CRC_MSB]
+///   Len = data_len + 4
+class RfidService implements IRfidService {
+  static const _defaultTimeoutSeconds = 5;
+
+  // Inventory komutu sabit parametreleri
+  static const _inventoryData = [
+    0x04, // QValue
+    0x00, // Session
+    0x00, // MaskMem
+    0x80, // Ant (anten1)
+    0x14, // Scantime (20 × 100ms = 2 sn)
+  ];
+
+  Socket? _socket;
+  String? _host;
+  int? _port;
+
+  @override
+  bool get isConnected => _socket != null;
+
+  // ---------------------------------------------------------------------------
+  // Bağlantı
+  // ---------------------------------------------------------------------------
+
+  @override
+  Future<Result<void>> connect(String host, int port) async {
+    if (_socket != null) return const Result.ok(null);
+
+    try {
+      _socket = await Socket.connect(host, port, timeout: const Duration(seconds: _defaultTimeoutSeconds));
+      _host = host;
+      _port = port;
+
+      MedLogger.info(
+        unit: 'RfidService',
+        swreq: 'SWREQ-RFID-001',
+        message: 'RFID okuyucuya bağlanıldı',
+        context: {'host': host, 'port': port},
+      );
+
+      return const Result.ok(null);
+    } on SocketException catch (e) {
+      MedLogger.error(
+        unit: 'RfidService',
+        swreq: 'SWREQ-RFID-001',
+        message: 'TCP bağlantı hatası',
+        context: {'error': e.message},
+      );
+      return Result.error(ServiceException(message: 'RFID okuyucuya bağlanılamadı: ${e.message}', statusCode: 503));
+    }
+  }
+
+  @override
+  Future<void> disconnect() async {
+    await _socket?.close();
+    _socket = null;
+    MedLogger.info(unit: 'RfidService', swreq: 'SWREQ-RFID-001', message: 'RFID bağlantısı kapatıldı');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Scan
+  // ---------------------------------------------------------------------------
+
+  @override
+  Future<Result<List<RfidTag>>> scan() async {
+    final socket = _socket;
+    if (socket == null) {
+      return Result.error(
+        ServiceException(message: 'RFID servisi bağlı değil. Önce connect() çağrılmalı.', statusCode: 503),
+      );
+    }
+
+    try {
+      final packet = _buildPacket(0x01, _inventoryData);
+      socket.add(packet);
+
+      // EPC → en yüksek RSSI kaydedilir (duplicate filtreleme)
+      final Map<String, RfidTag> tagMap = {};
+
+      await for (final chunk in socket.timeout(const Duration(seconds: _defaultTimeoutSeconds)).cast<List<int>>()) {
+        final resp = Uint8List.fromList(chunk);
+
+        // Minimum cevap boyutu kontrolü
+        if (resp.length < 18) continue;
+
+        final status = resp[3];
+
+        if (status == 0xFF) {
+          // Tag bulunamadı
+          break;
+        }
+
+        if (status == 0x03 || status == 0x01) {
+          final tag = _parseTag(resp);
+          if (tag != null) {
+            final existing = tagMap[tag.epc];
+            if (existing == null || tag.rssi > existing.rssi) {
+              tagMap[tag.epc] = tag;
+            }
+          }
+        }
+
+        if (status == 0x01) {
+          // Son paket — tarama tamamlandı
+          break;
+        }
+      }
+
+      final tags = tagMap.values.toList();
+
+      MedLogger.info(
+        unit: 'RfidService',
+        swreq: 'SWREQ-RFID-002',
+        message: 'Scan tamamlandı',
+        context: {'tagCount': tags.length},
+      );
+
+      return Result.ok(tags);
+    } on TimeoutException {
+      MedLogger.error(unit: 'RfidService', swreq: 'SWREQ-RFID-002', message: 'Scan timeout');
+      return Result.error(ServiceException(message: 'RFID scan zaman aşımına uğradı.', statusCode: 408));
+    } catch (e) {
+      MedLogger.error(
+        unit: 'RfidService',
+        swreq: 'SWREQ-RFID-002',
+        message: 'Scan hatası',
+        context: {'error': e.toString()},
+      );
+      return Result.error(ServiceException(message: 'RFID scan hatası: $e', statusCode: 500));
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // RF Güç
+  // ---------------------------------------------------------------------------
+
+  @override
+  Future<Result<void>> setPower(int dbm) async {
+    final socket = _socket;
+    if (socket == null) {
+      return Result.error(ServiceException(message: 'RFID servisi bağlı değil.', statusCode: 503));
+    }
+
+    try {
+      final packet = _buildPacket(0x2F, [dbm]);
+      socket.add(packet);
+
+      MedLogger.info(unit: 'RfidService', swreq: 'SWREQ-RFID-003', message: 'RF güç ayarlandı', context: {'dbm': dbm});
+
+      return const Result.ok(null);
+    } catch (e) {
+      return Result.error(ServiceException(message: 'RF güç ayar hatası: $e', statusCode: 500));
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Yardımcı metodlar
+  // ---------------------------------------------------------------------------
+
+  /// Protokol paketini oluşturur.
+  /// TX: [Len][Addr=0x00][CMD][Data...][CRC_LSB][CRC_MSB]
+  /// Len = data_len + 4
+  Uint8List _buildPacket(int cmd, List<int> data) {
+    final len = data.length + 4;
+    final payload = [len, 0x00, cmd, ...data];
+    final crc = _crc16(payload);
+    return Uint8List.fromList([...payload, ...crc]);
+  }
+
+  /// CRC-16/MCRF4XX
+  /// poly=0x1021, init=0xFFFF, reflected, LSB-first
+  List<int> _crc16(List<int> data) {
+    var crc = 0xFFFF;
+    for (final b in data) {
+      crc ^= b;
+      for (var i = 0; i < 8; i++) {
+        crc = (crc & 1) != 0 ? (crc >> 1) ^ 0x8408 : crc >> 1;
+      }
+    }
+    return [crc & 0xFF, (crc >> 8) & 0xFF];
+  }
+
+  /// Cevap paketinden RfidTag parse eder.
+  /// RX: 15 00 01 [Status] 01 01 [EPC 12byte] [Ant] [RSSI] [CRC2]
+  /// EPC: resp[5:17] (12 byte)
+  /// RSSI: resp[17] signed byte
+  RfidTag? _parseTag(Uint8List resp) {
+    if (resp.length < 19) return null;
+
+    final epcBytes = resp.sublist(5, 17);
+    final epc = epcBytes.map((b) => b.toRadixString(16).padLeft(2, '0').toUpperCase()).join();
+
+    // Signed byte dönüşümü
+    final rawRssi = resp[17];
+    final rssi = rawRssi >= 128 ? rawRssi - 256 : rawRssi;
+
+    final antenna = resp[16];
+
+    return RfidTag(epc: epc, rssi: rssi, antenna: antenna);
+  }
+}

--- a/apps/pharmed-client/lib/core/providers/hardware_providers.dart
+++ b/apps/pharmed-client/lib/core/providers/hardware_providers.dart
@@ -4,6 +4,9 @@ import '../flavor/app_flavor.dart';
 import '../hardware/service/cabin_operation/cabin_operation_service.dart';
 import '../hardware/service/cabin_operation/i_cabin_operation_service.dart';
 import '../hardware/service/cabin_operation/mock_cabin_operation_service.dart';
+import '../hardware/service/rfid/i_rfid_service.dart';
+import '../hardware/service/rfid/mock_rfid_service.dart';
+import '../hardware/service/rfid/rfid_service.dart';
 import '../hardware/service/serial_communication/i_serial_communication_service.dart';
 import '../hardware/service/serial_communication/mock_serial_communication_service.dart';
 import '../hardware/service/serial_communication/serial_communication_service.dart';
@@ -19,5 +22,12 @@ final cabinOperationServiceProvider = Provider<ICabinOperationService>((ref) {
   return switch (FlavorConfig.instance.flavor) {
     AppFlavor.mock || AppFlavor.dev => MockCabinOperationService(),
     AppFlavor.prod => CabinOperationService(serialService: ref.read(serialServiceProvider)),
+  };
+});
+
+final rfidServiceProvider = Provider<IRfidService>((ref) {
+  return switch (FlavorConfig.instance.flavor) {
+    AppFlavor.mock || AppFlavor.dev => MockRfidService(),
+    AppFlavor.prod => RfidService(),
   };
 });

--- a/apps/pharmed-client/lib/features/cabin/domain/usecase/verify_cabin_operation_usecase.dart
+++ b/apps/pharmed-client/lib/features/cabin/domain/usecase/verify_cabin_operation_usecase.dart
@@ -1,0 +1,90 @@
+// pharmed-client/features/cabin/domain/use_case/verify_cabinet_operation_use_case.dart
+
+import 'package:pharmed_core/pharmed_core.dart';
+import 'package:pharmed_ui/pharmed_ui.dart';
+
+import '../../../../core/hardware/model/rfid_tag.dart';
+import '../../../../core/hardware/service/rfid/i_rfid_service.dart';
+
+/// Kabin operasyonu öncesi ve sonrası RFID snapshot'larını karşılaştırarak
+/// kabinden çıkan (removed) ve kabine giren (added) tag'leri tespit eder.
+///
+/// Akış:
+///   1. [takeSnapshot] → T1 (çekmece açılmadan önce)
+///   2. Çekmece açılır, kullanıcı işlem yapar, çekmece kapanır
+///   3. [takeSnapshot] → T2 (çekmece kapandıktan sonra)
+///   4. [computeDelta(T1, T2)] → [RfidDelta]
+///
+/// Orchestration (sıralama ve çağrı zamanlaması) Notifier sorumluluğundadır.
+/// Bu UseCase yalnızca snapshot alma ve delta hesaplama yapar.
+class VerifyCabinetOperationUseCase {
+  const VerifyCabinetOperationUseCase(this._rfidService);
+
+  final IRfidService _rfidService;
+
+  /// Mevcut kabindeki tag'lerin anlık görüntüsünü alır.
+  Future<Result<List<RfidTag>>> takeSnapshot() async {
+    MedLogger.info(unit: 'VerifyCabinetOperationUseCase', swreq: 'SWREQ-RFID-010', message: 'Snapshot alınıyor');
+
+    final result = await _rfidService.scan();
+
+    result.when(
+      ok: (tags) => MedLogger.info(
+        unit: 'VerifyCabinetOperationUseCase',
+        swreq: 'SWREQ-RFID-010',
+        message: 'Snapshot alındı',
+        context: {'tagCount': tags.length},
+      ),
+      error: (e) => MedLogger.error(
+        unit: 'VerifyCabinetOperationUseCase',
+        swreq: 'SWREQ-RFID-010',
+        message: 'Snapshot hatası',
+        context: {'error': e.message},
+      ),
+    );
+
+    return result;
+  }
+
+  /// T1 ve T2 snapshot'larını karşılaştırarak delta hesaplar.
+  ///
+  /// [before] → T1: çekmece açılmadan önceki tag listesi
+  /// [after]  → T2: çekmece kapandıktan sonraki tag listesi
+  ///
+  /// [RfidDelta.removed] → T1'de var T2'de yok → kabinden çıkan ilaç
+  /// [RfidDelta.added]   → T2'de var T1'de yok → kabine giren ilaç
+  Result<RfidDelta> computeDelta(List<RfidTag> before, List<RfidTag> after) {
+    final beforeEpcs = before.map((t) => t.epc).toSet();
+    final afterEpcs = after.map((t) => t.epc).toSet();
+
+    final removed = before.where((t) => !afterEpcs.contains(t.epc)).toList();
+    final added = after.where((t) => !beforeEpcs.contains(t.epc)).toList();
+
+    final delta = RfidDelta(added: added, removed: removed);
+
+    MedLogger.info(
+      unit: 'VerifyCabinetOperationUseCase',
+      swreq: 'SWREQ-RFID-011',
+      message: 'Delta hesaplandı',
+      context: {'before': before.length, 'after': after.length, 'added': added.length, 'removed': removed.length},
+    );
+
+    return Result.ok(delta);
+  }
+}
+
+/// Kabin operasyonu sonucu RFID delta verisi.
+class RfidDelta {
+  /// T2'de var T1'de yok → kabine giren tag (iade, dolum vb.)
+  final List<RfidTag> added;
+
+  /// T1'de var T2'de yok → kabinden çıkan tag (alım, taburcu vb.)
+  final List<RfidTag> removed;
+
+  const RfidDelta({required this.added, required this.removed});
+
+  bool get isEmpty => added.isEmpty && removed.isEmpty;
+
+  @override
+  String toString() => 'RfidDelta(added: ${added.length}, removed: ${removed.length})';
+}

--- a/apps/pharmed-client/lib/main_dev.dart
+++ b/apps/pharmed-client/lib/main_dev.dart
@@ -11,6 +11,6 @@ void main() async {
   FlavorConfig.initialize(AppFlavor.dev);
   await AppBootstrap.init();
   MedLogger.configure(verboseLogging: true);
-  await appSettingsCache.resetSetup();
+  //await appSettingsCache.resetSetup();
   runApp(const ProviderScope(child: MyApp()));
 }

--- a/apps/pharmed-client/lib/main_mock.dart
+++ b/apps/pharmed-client/lib/main_mock.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:pharmed_client/core/cache/app_settings_cache.dart';
 import 'package:pharmed_client/core/providers/auth_providers.dart';
 import 'package:pharmed_client/core/providers/datasource_providers.dart';
 import 'package:pharmed_data/pharmed_data.dart';
@@ -17,7 +18,7 @@ void main() async {
   // Mock test için cache'i temizle
   final container = ProviderContainer();
   await container.read(cabinLocaleDataSourceProvider).clearAll();
-  //await appSettingsCache.resetSetup();
+  await appSettingsCache.resetSetup();
   container.dispose();
 
   runApp(

--- a/packages/pharmed_utils/lib/src/utils/device_info.dart
+++ b/packages/pharmed_utils/lib/src/utils/device_info.dart
@@ -13,7 +13,7 @@ class DeviceInfo {
     final macAddressRaw = deviceInfo.data['systemGUID'] ?? deviceInfo.data['deviceId'];
     // String macResult = macAddressRaw.toString().replaceAll(RegExp(r'^\{|\}$'), '');
     // TODO : Düzelt
-    String macResult = "15514B44A-6ET586-4734-9A5C-243C321234B9AS2118E";
+    String macResult = "15514B4A-6ET586-4734-9A5C-243C321234B9AS2118E";
     return macResult;
   }
 }


### PR DESCRIPTION
- Add RfidTag model (EPC, RSSI, antenna)
- Add IRfidService interface (persistent TCP connection)
- Implement RfidService via dart:io Socket (CRC-16/MCRF4XX, inventory loop)
- Add MockRfidService for dev/test flavor
- Add VerifyCabinetOperationUseCase with takeSnapshot() and computeDelta()
- Add RfidDelta model (added/removed tag lists)
- Add rfid_providers.dart (flavor-based DI)

Refs: SWREQ-RFID-001, SWREQ-RFID-002, SWREQ-RFID-003, SWREQ-RFID-010, SWREQ-RFID-011