### PR TITLE
fix:clear session witnessess on user change

### DIFF
--- a/apps/pharmed-client/lib/features/intake/master_intake/notifier/master_intake_notifier.dart
+++ b/apps/pharmed-client/lib/features/intake/master_intake/notifier/master_intake_notifier.dart
@@ -67,6 +67,22 @@ class MasterIntakeNotifier extends Notifier<MasterIntakeState> {
     _orchestrator.init(onStageChange: _onDrawerStage);
     ref.onDispose(_orchestrator.dispose);
 
+    // [Madde 5] Güvenlik: oturum sahibi değişirse (çıkış yapıldı veya farklı
+    // bir kullanıcı giriş yaptı) birikmiş şahit listesi TEMİZLENİR —
+    // _recentWitnesses bir sonraki kullanıcının ekranına sızmamalı.
+    // AuthSessionExpiring'de user aynı kaldığı için (countdown sırasında)
+    // temizlik TETİKLENMEZ — yalnızca gerçek login/logout/kullanıcı değişimi.
+    ref.listen(authNotifierProvider, (previous, next) {
+      AppUser? userOf(AuthState? s) => switch (s) {
+        AuthLoggedIn(:final user) => user,
+        AuthSessionExpiring(:final user) => user,
+        _ => null,
+      };
+      if (userOf(previous)?.id != userOf(next)?.id) {
+        _recentWitnesses.clear();
+      }
+    });
+
     // Hasta seçim notifier'ındaki filtre veya görünüm tipi değişince (sadece
     // MedicineSelection fazındayken, hasta zaten seçiliyken) tepki veririz.
     // İlk boot senkronizasyonu BURADA DEĞİL, init()'te — bkz. aşağı.


### PR DESCRIPTION
Refs #15

## Ne değişti
Şahitli alım akışında, oturum boyunca giriş yapmış şahitler
(`_recentWitnesses`) artık aktif kullanıcı değiştiğinde (çıkış yapıldığında veya farklı bir kullanıcı giriş yaptığında) temizleniyor.

## Neden
Madde 15'in asıl kapsamı, aynı kullanıcının oturumu içinde hasta değişse dahi şahidin korunmasıydı. Ancak mevcut implementasyon `_recentWitnesses`'ı yalnızca notifier'ın kendi ömrü boyunca tutuyordu — kullanıcı çıkış yapıp başka biri giriş yapsa bile bu liste temizlenmiyordu. Bu, bir kullanıcının onayladığı şahidin farklı bir kullanıcının oturumuna sessizce taşınmasına yol açabilecek bir güvenlik açığıydı.

## Davranış
- Aynı kullanıcı oturumunda hasta değiştirme → şahit korunur (önceki PR'daki davranış)
- Kullanıcı çıkış yapar / farklı kullanıcı giriş yapar → şahit listesi sıfırlanır, tekrar giriş istenir

## Test notu
QA'in test senaryosu issue #15 yorumlarında belirtildi.