### PR TITLE
feat:manage zero-stock assignments in unload screen

### DIFF
--- a/apps/pharmed-client/lib/features/unload/master_unload/notifier/master_unload_notifier.dart
+++ b/apps/pharmed-client/lib/features/unload/master_unload/notifier/master_unload_notifier.dart
@@ -2,6 +2,7 @@
 // Sınıf: Class B
 
 import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:pharmed_core/pharmed_core.dart';
 import 'package:pharmed_ui/pharmed_ui.dart';
@@ -21,6 +22,8 @@ class MasterUnloadNotifier extends Notifier<MasterUnloadState> {
 
   GetCabinAssignmentsWithCabinUseCase get _getAssignments => ref.read(getCabinAssignmentsWitCabinUseCaseProvider);
   CompleteMasterUnloadUseCase get _completeUnload => ref.read(completeMasterUnloadUseCaseProvider);
+  DeleteMedicineAssignmentUseCase get _deleteAssignment => ref.read(deleteAssignmentUseCaseProvider);
+  UpdateMedicineAssignmentUseCase get _updateAssignment => ref.read(updateMedicineAssignmentUseCaseProvider);
 
   @override
   MasterUnloadState build() {
@@ -423,5 +426,73 @@ class MasterUnloadNotifier extends Notifier<MasterUnloadState> {
     final next = List<CabinOperationDrawerJob>.from(jobs);
     next[index] = next[index].copyWith(status: status);
     return next;
+  }
+
+  /// "Sil": atama tamamen kaldırılır, liste yeniden çekilir.
+  Future<void> deleteAssignment(
+    MedicineAssignment assignment, {
+    ValueChanged<void>? onSuccess,
+    ValueChanged<String?>? onFailed,
+  }) async {
+    final s = state;
+    if (s is! MasterUnloadSelection) return;
+    final id = assignment.cabinDrawerId;
+    if (id == null) return;
+
+    state = s.copyWith(pendingAssignmentActionIds: {...s.pendingAssignmentActionIds, id});
+
+    final result = await _deleteAssignment.call(id);
+
+    result.when(
+      ok: (_) async {
+        onSuccess?.call(null);
+        await _reloadSelectionAfterQueue(s.cabinId);
+      },
+      error: (e) async {
+        final failure = CabinApiFailure(message: e.message);
+        final current = state;
+        if (current is MasterUnloadSelection) {
+          final cleared = {...current.pendingAssignmentActionIds}..remove(id);
+          state = current.copyWith(pendingAssignmentActionIds: cleared);
+        }
+        onFailed?.call(failure.message);
+      },
+    );
+  }
+
+  /// "Değiştir": mevcut atama, seçilen yeni ilaçla güncellenir
+  /// (muadil listesinden veya "Tüm İlaç Listesi"nden seçilmiş olabilir —
+  /// ikisi de aynı Medicine tipini döner, notifier ayrım yapmaz).
+  Future<void> replaceAssignment(
+    MedicineAssignment assignment,
+    Medicine newMedicine, {
+    ValueChanged<void>? onSuccess,
+    ValueChanged<String?>? onFailed,
+  }) async {
+    final s = state;
+    if (s is! MasterUnloadSelection) return;
+    final id = assignment.id;
+    if (id == null) return;
+
+    state = s.copyWith(pendingAssignmentActionIds: {...s.pendingAssignmentActionIds, id});
+
+    final updated = assignment.copyWith(medicine: newMedicine);
+    final result = await _updateAssignment.call(updated);
+
+    result.when(
+      ok: (_) async {
+        onSuccess?.call(null);
+        await _reloadSelectionAfterQueue(s.cabinId);
+      },
+      error: (e) {
+        final failure = CabinApiFailure(message: e.message);
+        final current = state;
+        if (current is MasterUnloadSelection) {
+          final cleared = {...current.pendingAssignmentActionIds}..remove(id);
+          state = current.copyWith(pendingAssignmentActionIds: cleared);
+        }
+        onFailed?.call(failure.message);
+      },
+    );
   }
 }

--- a/apps/pharmed-client/lib/features/unload/master_unload/notifier/master_unload_state.dart
+++ b/apps/pharmed-client/lib/features/unload/master_unload/notifier/master_unload_state.dart
@@ -28,12 +28,17 @@ final class MasterUnloadSelection extends MasterUnloadState {
     required this.medicines,
     this.selectedUnitIds = const {},
     this.search = '',
+    this.pendingAssignmentActionIds = const {},
   });
 
   final int cabinId;
   final List<MedicineAssignment> medicines;
   final Set<int> selectedUnitIds;
   final String search;
+
+  /// Sil/Değiştir isteği devam eden assignment id'leri —
+  /// ilgili satırın butonlarını kilitlemek/spinner göstermek için.
+  final Set<int> pendingAssignmentActionIds;
 
   List<MedicineAssignment> get visibleMedicines {
     if (search.trim().isEmpty) return medicines;
@@ -50,12 +55,18 @@ final class MasterUnloadSelection extends MasterUnloadState {
   List<MedicineAssignment> get selectedAssignments =>
       medicines.where((a) => selectedUnitIds.contains(a.cabinDrawerId)).toList();
 
-  MasterUnloadSelection copyWith({List<MedicineAssignment>? medicines, Set<int>? selectedUnitIds, String? search}) {
+  MasterUnloadSelection copyWith({
+    List<MedicineAssignment>? medicines,
+    Set<int>? selectedUnitIds,
+    String? search,
+    Set<int>? pendingAssignmentActionIds,
+  }) {
     return MasterUnloadSelection(
       cabinId: cabinId,
       medicines: medicines ?? this.medicines,
       selectedUnitIds: selectedUnitIds ?? this.selectedUnitIds,
       search: search ?? this.search,
+      pendingAssignmentActionIds: pendingAssignmentActionIds ?? this.pendingAssignmentActionIds,
     );
   }
 }

--- a/apps/pharmed-client/lib/features/unload/master_unload/view/master_unload_selection_view.dart
+++ b/apps/pharmed-client/lib/features/unload/master_unload/view/master_unload_selection_view.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:pharmed_core/pharmed_core.dart';
 import 'package:pharmed_ui/pharmed_ui.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
+import '../../../../core/providers/providers.dart';
 import '../../../../widgets/widgets.dart';
 import '../../../dashboard/dashboard.dart';
 import '../notifier/master_unload_notifier.dart';
@@ -29,6 +31,27 @@ class MasterUnloadSelectionView extends ConsumerWidget {
     if (selection == null) return const SizedBox.shrink();
 
     final items = selection.visibleMedicines;
+
+    SearchDataSource<Medicine> _equivalentsSource(int medicineId) {
+      return (skip, take, search) async {
+        final result = await ref
+            .read(getEquivalentMedicinesUseCaseProvider)
+            .execute(
+              medicineId,
+              params: PagedQueryParams(skip: skip, take: take, searchQuery: search),
+            );
+        return result.when(ok: (response) => Result.ok(response), error: (e) => Result.error(e));
+      };
+    }
+
+    SearchDataSource<Medicine> _allMedicinesSource() {
+      return (skip, take, search) async {
+        final result = await ref
+            .read(getMedicinesUseCaseProvider)
+            .call(PagedQueryParams(skip: skip, take: take, searchQuery: search));
+        return result.when(ok: (response) => Result.ok(response), error: (e) => Result.error(e));
+      };
+    }
 
     return CabinOperationSelectionLayout(
       left: CabinOverviewSelectionPanel(
@@ -57,6 +80,49 @@ class MasterUnloadSelectionView extends ConsumerWidget {
                 items: items,
                 selectedItemIds: selection.selectedUnitIds,
                 onToggle: notifier.toggleUnit,
+                onDelete: (assignment) => MessageUtils.showConfirmDeleteDialog(
+                  context: context,
+                  itemName: assignment.medicine?.name,
+                  onConfirm: () => notifier.deleteAssignment(
+                    assignment,
+                    onSuccess: (_) {
+                      if (!context.mounted) return;
+                      MessageUtils.showSuccessSnackbar(context, context.l10n.common_operationSuccessMessage);
+                    },
+                    onFailed: (msg) {
+                      if (!context.mounted) return;
+                      MessageUtils.showErrorSnackbar(context, msg);
+                    },
+                  ),
+                ),
+
+                onReplace: (assignment) async {
+                  final medicineId = assignment.medicine?.id;
+                  if (medicineId == null) return;
+
+                  final selected = await SelectionDialog.showWithFallback<Medicine>(
+                    context,
+                    title: context.l10n.unload_replaceMedicine_dialogTitle,
+                    primaryDataSource: _equivalentsSource(medicineId),
+                    secondaryDataSource: _allMedicinesSource(),
+                    secondaryToggleLabel: context.l10n.unload_replaceMedicine_allMedicinesButton,
+                    labelBuilder: (m) => m.name,
+                  );
+
+                  if (selected == null || !context.mounted) return;
+                  notifier.replaceAssignment(
+                    assignment,
+                    selected,
+                    onSuccess: (_) {
+                      if (!context.mounted) return;
+                      MessageUtils.showSuccessSnackbar(context, context.l10n.common_operationSuccessMessage);
+                    },
+                    onFailed: (msg) {
+                      if (!context.mounted) return;
+                      MessageUtils.showErrorSnackbar(context, msg);
+                    },
+                  );
+                },
               ),
         footer: selection.selectedAssignments.isNotEmpty
             ? MedButton(

--- a/apps/pharmed-client/lib/widgets/cabin_shell_widgets/selection/cabin_assignment_list_view.dart
+++ b/apps/pharmed-client/lib/widgets/cabin_shell_widgets/selection/cabin_assignment_list_view.dart
@@ -5,11 +5,20 @@ import 'package:pharmed_utils/pharmed_utils.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 class CabinAssignmentListView extends StatelessWidget {
-  const CabinAssignmentListView({super.key, required this.items, required this.selectedItemIds, this.onToggle});
+  const CabinAssignmentListView({
+    super.key,
+    required this.items,
+    required this.selectedItemIds,
+    this.onToggle,
+    this.onDelete,
+    this.onReplace,
+  });
 
   final List<MedicineAssignment> items;
   final Set<int> selectedItemIds;
   final ValueChanged<int>? onToggle;
+  final ValueChanged<MedicineAssignment>? onDelete;
+  final ValueChanged<MedicineAssignment>? onReplace;
 
   double _ratio(double v, double max) => max > 0 ? (v / max).clamp(0.0, 1.0) : 0.0;
 
@@ -27,6 +36,8 @@ class CabinAssignmentListView extends StatelessWidget {
             Expanded(child: Text(context.l10n.cabinAssignmentList_locationColumn, style: textStyle)),
             Expanded(child: Text(context.l10n.cabinAssignmentList_stockColumn, style: textStyle)),
             SizedBox(width: 100, child: Text(context.l10n.cabinAssignmentList_fillLevelColumn, style: textStyle)),
+            if (onDelete != null || onReplace != null)
+              SizedBox(width: 96, child: Text(context.l10n.cabinAssignmentList_actionsColumn, style: textStyle)),
           ],
         ),
         SizedBox(height: 12.0),
@@ -98,6 +109,31 @@ class CabinAssignmentListView extends StatelessWidget {
                           color: color,
                         ),
                       ),
+                      if (onDelete != null || onReplace != null)
+                        SizedBox(
+                          width: 96,
+                          child:
+                              assignment.totalQuantity <=
+                                  0 // [Madde 10] sadece stok 0'ken
+                              ? Row(
+                                  mainAxisAlignment: MainAxisAlignment.end,
+                                  children: [
+                                    if (onReplace != null)
+                                      IconButton(
+                                        icon: Icon(PhosphorIcons.arrowsClockwise(), size: 18, color: MedColors.blue),
+                                        tooltip: context.l10n.cabinAssignmentList_replaceTooltip,
+                                        onPressed: () => onReplace!(assignment),
+                                      ),
+                                    if (onDelete != null)
+                                      IconButton(
+                                        icon: Icon(PhosphorIcons.trash(), size: 18, color: MedColors.red),
+                                        tooltip: context.l10n.cabinAssignmentList_deleteTooltip,
+                                        onPressed: () => onDelete!(assignment),
+                                      ),
+                                  ],
+                                )
+                              : const SizedBox.shrink(),
+                        ),
                     ],
                   ),
                 ),

--- a/packages/pharmed_ui/lib/src/l10n/app_en.arb
+++ b/packages/pharmed_ui/lib/src/l10n/app_en.arb
@@ -4797,5 +4797,10 @@
 "refillList_column_targetQuantity": "Target Quantity",
 "refillList_column_filledQuantity": "Filled Quantity",
 "fault_cellValueSolved": "Solved",
-"fault_cellValueUnsolved": "Unsolved"
+"fault_cellValueUnsolved": "Unsolved",
+"cabinAssignmentList_actionsColumn": "Actions",
+"cabinAssignmentList_deleteTooltip": "Delete Assignment",
+"cabinAssignmentList_replaceTooltip": "Replace Medicine",
+"unload_replaceMedicine_dialogTitle": "Select Equivalent Medicine",
+"unload_replaceMedicine_allMedicinesButton": "All Medicines List"
 }

--- a/packages/pharmed_ui/lib/src/l10n/app_fr.arb
+++ b/packages/pharmed_ui/lib/src/l10n/app_fr.arb
@@ -4249,5 +4249,10 @@
 "refillList_column_targetQuantity": "Quantité cible",
 "refillList_column_filledQuantity": "Quantité remplie",
 "fault_cellValueSolved": "Résolu",
-"fault_cellValueUnsolved": "Non résolu"
+"fault_cellValueUnsolved": "Non résolu",
+"cabinAssignmentList_actionsColumn": "Actions",
+"cabinAssignmentList_deleteTooltip": "Supprimer L'Affectation",
+"cabinAssignmentList_replaceTooltip": "Remplacer Le Médicament",
+"unload_replaceMedicine_dialogTitle": "Sélectionner Un Médicament Équivalent",
+"unload_replaceMedicine_allMedicinesButton": "Liste De Tous Les Médicaments"
 }

--- a/packages/pharmed_ui/lib/src/l10n/app_localizations.dart
+++ b/packages/pharmed_ui/lib/src/l10n/app_localizations.dart
@@ -11972,6 +11972,36 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Unsolved'**
   String get fault_cellValueUnsolved;
+
+  /// No description provided for @cabinAssignmentList_actionsColumn.
+  ///
+  /// In en, this message translates to:
+  /// **'Actions'**
+  String get cabinAssignmentList_actionsColumn;
+
+  /// No description provided for @cabinAssignmentList_deleteTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete Assignment'**
+  String get cabinAssignmentList_deleteTooltip;
+
+  /// No description provided for @cabinAssignmentList_replaceTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Replace Medicine'**
+  String get cabinAssignmentList_replaceTooltip;
+
+  /// No description provided for @unload_replaceMedicine_dialogTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Select Equivalent Medicine'**
+  String get unload_replaceMedicine_dialogTitle;
+
+  /// No description provided for @unload_replaceMedicine_allMedicinesButton.
+  ///
+  /// In en, this message translates to:
+  /// **'All Medicines List'**
+  String get unload_replaceMedicine_allMedicinesButton;
 }
 
 class _AppLocalizationsDelegate

--- a/packages/pharmed_ui/lib/src/l10n/app_localizations_ar.dart
+++ b/packages/pharmed_ui/lib/src/l10n/app_localizations_ar.dart
@@ -6779,4 +6779,19 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get fault_cellValueUnsolved => 'Unsolved';
+
+  @override
+  String get cabinAssignmentList_actionsColumn => 'Actions';
+
+  @override
+  String get cabinAssignmentList_deleteTooltip => 'Delete Assignment';
+
+  @override
+  String get cabinAssignmentList_replaceTooltip => 'Replace Medicine';
+
+  @override
+  String get unload_replaceMedicine_dialogTitle => 'Select Equivalent Medicine';
+
+  @override
+  String get unload_replaceMedicine_allMedicinesButton => 'All Medicines List';
 }

--- a/packages/pharmed_ui/lib/src/l10n/app_localizations_en.dart
+++ b/packages/pharmed_ui/lib/src/l10n/app_localizations_en.dart
@@ -6778,4 +6778,19 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get fault_cellValueUnsolved => 'Unsolved';
+
+  @override
+  String get cabinAssignmentList_actionsColumn => 'Actions';
+
+  @override
+  String get cabinAssignmentList_deleteTooltip => 'Delete Assignment';
+
+  @override
+  String get cabinAssignmentList_replaceTooltip => 'Replace Medicine';
+
+  @override
+  String get unload_replaceMedicine_dialogTitle => 'Select Equivalent Medicine';
+
+  @override
+  String get unload_replaceMedicine_allMedicinesButton => 'All Medicines List';
 }

--- a/packages/pharmed_ui/lib/src/l10n/app_localizations_fr.dart
+++ b/packages/pharmed_ui/lib/src/l10n/app_localizations_fr.dart
@@ -6938,4 +6938,21 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get fault_cellValueUnsolved => 'Non résolu';
+
+  @override
+  String get cabinAssignmentList_actionsColumn => 'Actions';
+
+  @override
+  String get cabinAssignmentList_deleteTooltip => 'Supprimer L\'Affectation';
+
+  @override
+  String get cabinAssignmentList_replaceTooltip => 'Remplacer Le Médicament';
+
+  @override
+  String get unload_replaceMedicine_dialogTitle =>
+      'Sélectionner Un Médicament Équivalent';
+
+  @override
+  String get unload_replaceMedicine_allMedicinesButton =>
+      'Liste De Tous Les Médicaments';
 }

--- a/packages/pharmed_ui/lib/src/l10n/app_localizations_tr.dart
+++ b/packages/pharmed_ui/lib/src/l10n/app_localizations_tr.dart
@@ -6730,4 +6730,19 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get fault_cellValueUnsolved => 'Çözülmedi';
+
+  @override
+  String get cabinAssignmentList_actionsColumn => 'İşlemler';
+
+  @override
+  String get cabinAssignmentList_deleteTooltip => 'Atamayı Sil';
+
+  @override
+  String get cabinAssignmentList_replaceTooltip => 'İlacı Değiştir';
+
+  @override
+  String get unload_replaceMedicine_dialogTitle => 'Muadil İlaç Seç';
+
+  @override
+  String get unload_replaceMedicine_allMedicinesButton => 'Tüm İlaç Listesi';
 }

--- a/packages/pharmed_ui/lib/src/l10n/app_tr.arb
+++ b/packages/pharmed_ui/lib/src/l10n/app_tr.arb
@@ -8832,5 +8832,25 @@
 "fault_cellValueUnsolved": "Çözülmedi",
 "@fault_cellValueUnsolved": {
   "description": "Table cell value shown for the status column when a fault/malfunction record's isSolved flag is false"
+},
+"cabinAssignmentList_actionsColumn": "İşlemler",
+"@cabinAssignmentList_actionsColumn": {
+  "description": "Column header in the cabin assignment list for the delete/replace action buttons, shown only when the row's stock is zero"
+},
+"cabinAssignmentList_deleteTooltip": "Atamayı Sil",
+"@cabinAssignmentList_deleteTooltip": {
+  "description": "Tooltip for the delete icon button on a zero-stock assignment row in the cabin assignment list"
+},
+"cabinAssignmentList_replaceTooltip": "İlacı Değiştir",
+"@cabinAssignmentList_replaceTooltip": {
+  "description": "Tooltip for the replace icon button on a zero-stock assignment row in the cabin assignment list"
+},
+"unload_replaceMedicine_dialogTitle": "Muadil İlaç Seç",
+"@unload_replaceMedicine_dialogTitle": {
+  "description": "Title of the dialog shown when replacing a zero-stock assignment; initially lists equivalent medicines, can be toggled to the full medicine list"
+},
+"unload_replaceMedicine_allMedicinesButton": "Tüm İlaç Listesi",
+"@unload_replaceMedicine_allMedicinesButton": {
+  "description": "Toggle button inside the replace-medicine dialog that switches from the equivalent-medicines list to the full medicine list"
 }
 }

--- a/packages/pharmed_ui/lib/src/l10n/untranslated_en.json
+++ b/packages/pharmed_ui/lib/src/l10n/untranslated_en.json
@@ -1606,6 +1606,11 @@
     "refillList_column_targetQuantity",
     "refillList_column_filledQuantity",
     "fault_cellValueSolved",
-    "fault_cellValueUnsolved"
+    "fault_cellValueUnsolved",
+    "cabinAssignmentList_actionsColumn",
+    "cabinAssignmentList_deleteTooltip",
+    "cabinAssignmentList_replaceTooltip",
+    "unload_replaceMedicine_dialogTitle",
+    "unload_replaceMedicine_allMedicinesButton"
   ]
 }

--- a/packages/pharmed_ui/lib/src/widgets/inputs/med_selection_dialog.dart
+++ b/packages/pharmed_ui/lib/src/widgets/inputs/med_selection_dialog.dart
@@ -35,6 +35,8 @@ class SelectionDialog<T extends Selectable> extends StatefulWidget {
     this.pageSize = 20,
     this.multi = false,
     this.initiallySelected,
+    this.secondaryDataSource,
+    this.secondaryToggleLabel,
   });
 
   final String title;
@@ -44,6 +46,8 @@ class SelectionDialog<T extends Selectable> extends StatefulWidget {
   final int pageSize;
   final bool multi;
   final List<T>? initiallySelected;
+  final SearchDataSource<T>? secondaryDataSource;
+  final String? secondaryToggleLabel;
 
   static Future<T?> show<T extends Selectable>(
     BuildContext context, {
@@ -91,6 +95,32 @@ class SelectionDialog<T extends Selectable> extends StatefulWidget {
     );
   }
 
+  static Future<T?> showWithFallback<T extends Selectable>(
+    BuildContext context, {
+    required String title,
+    required SearchDataSource<T> primaryDataSource,
+    required SearchDataSource<T> secondaryDataSource,
+    required String secondaryToggleLabel,
+    required String? Function(T item) labelBuilder,
+    String? Function(T item)? subtitleBuilder,
+    int pageSize = 20,
+  }) {
+    return showDialog<T>(
+      context: context,
+      barrierColor: const Color(0x800F192D),
+      builder: (_) => SelectionDialog<T>(
+        title: title,
+        dataSource: primaryDataSource,
+        secondaryDataSource: secondaryDataSource,
+        secondaryToggleLabel: secondaryToggleLabel,
+        labelBuilder: labelBuilder,
+        subtitleBuilder: subtitleBuilder,
+        pageSize: pageSize,
+        multi: false,
+      ),
+    );
+  }
+
   @override
   State<SelectionDialog<T>> createState() => _SelectionDialogState<T>();
 }
@@ -105,10 +135,14 @@ class _SelectionDialogState<T extends Selectable> extends State<SelectionDialog<
   String _search = '';
   T? _selected;
   late Set<Object?> _selectedIds;
+  bool _useSecondary = false;
 
   final _searchController = TextEditingController();
   final _scrollController = ScrollController();
   Timer? _debounce;
+
+  SearchDataSource<T> get _activeDataSource =>
+      (_useSecondary && widget.secondaryDataSource != null) ? widget.secondaryDataSource! : widget.dataSource;
 
   @override
   void initState() {
@@ -149,7 +183,7 @@ class _SelectionDialogState<T extends Selectable> extends State<SelectionDialog<
     });
 
     try {
-      final result = await widget.dataSource(skip, widget.pageSize, _search.isEmpty ? null : _search);
+      final result = await _activeDataSource(skip, widget.pageSize, _search.isEmpty ? null : _search);
       if (!mounted) return;
 
       result.when(
@@ -182,6 +216,19 @@ class _SelectionDialogState<T extends Selectable> extends State<SelectionDialog<
       _isFetchingMore = true;
       _fetch();
     }
+  }
+
+  void _toggleSource() {
+    setState(() {
+      _useSecondary = !_useSecondary;
+      _items.clear();
+      _totalCount = -1;
+      _selected = null;
+      _selectedIds = {};
+      _searchController.clear();
+      _search = '';
+    });
+    _fetch(reset: true);
   }
 
   void _onSearchChanged(String value) {
@@ -248,7 +295,14 @@ class _SelectionDialogState<T extends Selectable> extends State<SelectionDialog<
             _DialogHeader(
               title: widget.title,
               onClose: () => Navigator.of(context).pop(),
-              action: widget.multi
+              action: widget.secondaryDataSource != null
+                  ? MedButton(
+                      label: _useSecondary ? (widget.title) : widget.secondaryToggleLabel!,
+                      variant: MedButtonVariant.ghost,
+                      size: MedButtonSize.sm,
+                      onPressed: _toggleSource,
+                    )
+                  : widget.multi
                   ? MedButton(
                       label: (_selectedIds.length == _items.length && _items.isNotEmpty)
                           ? context.l10n.common_deselectAllButton
@@ -335,9 +389,6 @@ class _SelectionDialogState<T extends Selectable> extends State<SelectionDialog<
   }
 }
 
-// ─────────────────────────────────────────────────────────────────
-// Header — gradient token'a bağlandı, kapat butonu MedRectangleIconButton
-// ─────────────────────────────────────────────────────────────────
 class _DialogHeader extends StatelessWidget {
   const _DialogHeader({required this.title, required this.onClose, this.action});
 


### PR DESCRIPTION
Refs #16

## Özet
İlaç boşaltma ekranında, stoğu 0'a düşen atamalar için "Sil" ve "Değiştir" aksiyonları eklendi (Madde 10).

## Ne değişti
- `CabinAssignmentListView`: stoğu 0 olan satırlarda kalıcı Sil/Değiştir ikon butonları (`onDelete`/`onReplace` - opsiyonel, diğer ekranları etkilemez)
- `MasterUnloadNotifier`: `deleteAssignment()` / `replaceAssignment()` - `DeleteMedicineAssignmentUseCase` / `UpdateMedicineAssignmentUseCase` kullanır, `onSuccess`/`onFailed` callback'leriyle sonuçlanır
- `MasterUnloadSelection`: `pendingAssignmentActionIds` alanı (işlem sürerken satırı kilitlemek için)
- `SelectionDialog`: opsiyonel `secondaryDataSource` + `showWithFallback()` - "Tüm İlaç Listesi" toggle'ı için, mevcut tek-kaynaklı kullanımları (`MedSelectionField` vb.) etkilemez
- 5 yeni ARB key, TR/EN/FR

## Mimari not
Sil/Değiştir hataları bilinçli olarak `MasterUnloadError`/kuyruk hata akışına (`ref.listen`'daki isQueueError dialogu) sokulmadı, bu işlemler donanım kuyruğuyla ilgisiz, state'in error koluna hiç uğramıyor.

## Madde metninden sapma
Bkz. Issue #16 comment. Dialog yerine kalıcı buton tercih edildi, gerekçe orada.